### PR TITLE
Fixes issues with being able to access the chooser when not logged in

### DIFF
--- a/frontend/app/routes/chooser.js
+++ b/frontend/app/routes/chooser.js
@@ -1,4 +1,5 @@
 import Route                 from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { on }                from '@ember/object/evented';
 import { inject as service } from '@ember/service';
 import { Promise }           from 'rsvp';
@@ -7,7 +8,8 @@ import EmberObject           from '@ember/object';
 
 const { stringify, parse } = JSON;
 
-export default Route.extend({
+export default Route.extend(AuthenticatedRouteMixin, {
+  search: service(),
   toolbar: service(),
   simplifyToolbar: on('activate', function(){
     this.set('toolbar.isSimplified', true);
@@ -15,6 +17,10 @@ export default Route.extend({
   unsimplifyToolbar: on('deactivate', function(){
     this.set('toolbar.isSimplified', false);
   }),
+  activate(){
+    this._super(...arguments);
+    this.get('search').getPage();
+  },
   model(){
     if(typeof window === 'undefined') return A();
     if(!window.opener) return A();


### PR DESCRIPTION
#### How to recreate the bug:
- Log out of http://laistassets.scprdev.org
- Navigate to http://laistassets.scprdev.org/a/chooser
- It displays the chooser ui with no images in the grid to the right

#### Expected behavior:
It should instead redirect the user to the `/login` page, and upon successfully logging in, redirect back to `/a/chooser` with images loaded up in the right grid.

#### Changes presented in this PR:
The AssetHost frontend uses [ember simple auth](https://github.com/simplabs/ember-simple-auth) to manage authenticated route handling. In the walkthrough linked [here](https://github.com/simplabs/ember-simple-auth#walkthrough), under the `To make a route in the application accessible only when the session is authenticated` section, it explains you can add a mixin to the route that handles this for you.

Ben already went ahead and did it like this for the `index` route (example [linked here](https://github.com/SCPR/AssetHost/blob/f0cb4d38dfbcc2a439e977d6776e46440862115e/frontend/app/routes/index.js#L14)), so I discovered that it's just a matter of importing the mixin at the top and including it in the `Route.extend()` declaration. I also added an `activate()` hook (detailed [here](https://www.emberjs.com/api/ember/2.14/classes/Ember.Route/methods/activate?anchor=activate)) so that the assets can be fetched when the route becomes activated again after login is successful. Otherwise it will still take you to a page with no assets on the right grid (despite being logged in).