### PR TITLE
Fixes return array when adding photos to TinyMCE

### DIFF
--- a/frontend/app/routes/chooser.js
+++ b/frontend/app/routes/chooser.js
@@ -52,7 +52,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       const source = this.source,
             origin = this.origin;
       if(!(source && origin)) return;
-      const model = parse(stringify(this.controller.get('model'))).map(m => delete m.shouldPersistCaption);
+      const model = this.controller.get('model').toArray();
       source.postMessage(model, origin);
       window.close();
     }


### PR DESCRIPTION
#### How to recreate the bug:
- Navigate to an entry on laist.scprdev.org's cms
- Click the `AssetHost` button in the text editor, choose a photo, and click `Save and Close`
- The popup should close, but no photo is added.

#### Expected behavior
Photo(s) should be added where the cursor is after the popup closes.

#### Changes presented in this PR
This line, `const model = parse(stringify(this.controller.get('model'))).map(m => delete m.shouldPersistCaption);`, evaluates to `[true, ...]`. This is because a map is done to the array of images, and the return of a `delete` command is true when it is successful. When the CMS window receives the array, it's looking for objects with properties such as `urls.eight`, but because those are undefined, it doesn't add any elements.

I think `this.controller.get('model')` was stringified and parsed in the first place to turn it into a vanilla javascript array (otherwise, its an object that is array like, but has ember functions decorated on top of it). However, rather than doing a stringify and parse, I think it might be better to just use ember's `toArray()` function to bring it back to a vanilla array object ([reference](https://www.emberjs.com/api/ember/2.14/classes/Ember.Array/methods/toArray?anchor=toArray))

#### Note
I'm not really sure why it worked sometime last week before I left for vacation, and what difference there was in the codebase between then and now, but I think this is what Ben intended.