### PR TITLE
Fixes "Failed to save Asset" bug

### DIFF
--- a/frontend/app/services/asset-upload.js
+++ b/frontend/app/services/asset-upload.js
@@ -4,6 +4,9 @@ import { bind } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 
 function pushToStore(asset, response, store){
+  // Capture the localFileURL from the placeholder record
+  const localFileURL = asset.get('localFileURL');
+
   // Unload the placeholder loading record
   asset.unloadRecord();
 
@@ -16,7 +19,7 @@ function pushToStore(asset, response, store){
   const pushedAsset = store.push({ data: normalizedRecord });
 
   // Set the image to the localFileURL so that there isn't a grey box during the switch
-  pushedAsset.set('localFileURL', asset.get('localFileURL'));
+  pushedAsset.set('localFileURL', localFileURL);
 };
 
 function uploadURL(asset, url){

--- a/frontend/app/services/asset-upload.js
+++ b/frontend/app/services/asset-upload.js
@@ -27,7 +27,7 @@ function uploadURL(asset, url){
   asset.set('localFileURL', url);
   const API = this.get('API');
   return API.post('assets', { data: { url } })
-           .then(response => pushToStore(asset, response, store));
+           .then(body => pushToStore(asset, { body }, store));
 }
 
 function uploadFile(asset, file){


### PR DESCRIPTION
#### How to recreate the bug:
- Upload an image on LAist Assethost
- After the upload is complete, click it, change one of the fields (e.g. title) and click save
- The toast notification appears saying that it failed to save the asset
- The changed field only stays for that session, but upon refreshing, the changed field is gone (so the data doesn't persist)

#### Expected behavior
Saving meta information immediately after an upload should successfully update/persist, and a success toast message should be appear.

#### Changes presented in this PR
The underlying issue is that an asset record is created in the store before the upload process begins, and then the properties are applied to the asset record after the upload process is complete. Because the asset record itself hadn't performed a `save()`, it still has the property `isNew=true`, so when you try to call `save()` later, it tries to post to the `/api/assets` endpoint instead of putting to the `/api/assets/{asset.id}` endpoint.

I was thinking that we could post an asset, get an asset id back, and the use the put endpoint. Unfortunately, there's no way to send a post to `/api/assets` and create a backend record without also uploading a file at the same time, and I think that's still the right behavior for that endpoint as it protects against accidentally creating a lot of empty asset records. From there, I decided it might be better to just manually replace the placeholder asset record and push a new record into the store with the response from the API. The pattern then becomes:
- Create placeholder asset record that shows the user the asset is in the process of uploading
- Perform a POST API call with the file, and then from the response:
  - [Unload](https://www.emberjs.com/api/ember-data/3.3/classes/DS.Model/methods/unloadRecord?anchor=unloadRecord) the placeholder asset record
  - [Push](https://www.emberjs.com/api/ember-data/3.3/classes/DS.Store/methods/push?anchor=push) the response data to the store, and the newly pushed record will have `isNew=false`
- When you try to save meta information, it should now give the correct notification and persist on the db

Surprisingly, the switch between the "placeholder" and the "real" record is unnoticeable and seems identical to the way it appears now.