### PR TITLE
Fixes persistence issues when updating an asset

### DIFF
--- a/frontend/app/controllers/asset.js
+++ b/frontend/app/controllers/asset.js
@@ -118,6 +118,18 @@ export default Controller.extend({
     },
     setGravity(gravity){
       this.set('asset.image_gravity', gravity[1]);
+    },
+    updateTakenAt(date){
+      // Build a new Date object
+      const newDate = new Date(date);
+
+      // Because we're building a date object from a YYYY-MM-DD (which has no information about timezones),
+      // the ISOString will display as a day earlier in LA. We have to shift it so that it matches the date the user chose.
+      var utcShift = new Date(newDate.getTime() + newDate.getTimezoneOffset() * 60000);
+
+      // Set `taken_at` for displaying on the frontend. Set `image_taken` for putting the new date to the server.
+      this.set('asset.taken_at', utcShift.toISOString());
+      this.set('asset.image_taken', utcShift);
     }
   }
 });

--- a/frontend/app/models/asset.js
+++ b/frontend/app/models/asset.js
@@ -15,6 +15,7 @@ export default DS.Model.extend({
   notes:           attr('string'),
   created_at:      attr('date'),
   taken_at:        attr('date'),
+  image_taken:     attr('date'),
   native:          attr(),
   image_file_size: attr(),
   url:             attr('string'),
@@ -28,6 +29,21 @@ export default DS.Model.extend({
     return (this.get('keywords') || '')
       .split(/\s*,\s*/g)
       .filter(k => k.length);
+  }),
+  takenAtFormatted:     computed('taken_at', function(){
+    // We need to format the date to YYYY-MM-DD to make it work with the ember-paper date picker
+    const takenAt = this.get('taken_at');
+    if (takenAt) {
+      var d = new Date(takenAt),
+          month = '' + (d.getMonth() + 1),
+          day = '' + d.getDate(),
+          year = d.getFullYear();
+
+      if (month.length < 2) month = '0' + month;
+      if (day.length < 2) day = '0' + day;
+
+      return [year, month, day].join('-');
+    }
   }),
   tileURL:         computed('localFileURL', 'urls.lsquare', function(){
     const lsquare = this.get('urls.lsquare'),

--- a/frontend/app/templates/application.hbs
+++ b/frontend/app/templates/application.hbs
@@ -22,6 +22,7 @@
         </div>
       {{/if}}
       <div class="toolbar-component__buttons">
+        {{paper-button label="Chooser" href=(href-to "chooser")}}
         {{#if (can user "assets" "read")}}
           {{paper-button label="Assets" href=(href-to "index")}}
         {{/if}}

--- a/frontend/app/templates/asset.hbs
+++ b/frontend/app/templates/asset.hbs
@@ -61,18 +61,14 @@
       <div class="asset-editor__attributes">
         <div class="asset-editor__attributes-row">
           <div class="asset-editor__attribute-name">Owner</div>
-          {{paper-input class="asset-editor__attribute-value" value=asset.owner onChange=(mut asset.owner)}}
-        </div>
-        <div class="asset-editor__attributes-row">
-          <div class="asset-editor__attribute-name">URL</div>
-          {{paper-input class="asset-editor__attribute-value" value='' onChange=null}}
+          {{paper-input class="asset-editor__attribute-value" value=asset.owner onChange=(action (mut asset.owner))}}
         </div>
       </div>
       <h2>Metadata</h2>
       <div class="asset-editor__attributes">
         <div class="asset-editor__attributes-row">
           <div class="asset-editor__attribute-name">Image taken</div>
-          {{paper-input class="asset-editor__attribute-value" type="date" value='' onChange=null}}
+          {{paper-input class="asset-editor__attribute-value" type="date" value=asset.takenAtFormatted onChange=(action "updateTakenAt")}}
         </div>
         <div class="asset-editor__attributes-row">
           <div class="asset-editor__attribute-name">Image Gravity</div>

--- a/frontend/app/templates/index.hbs
+++ b/frontend/app/templates/index.hbs
@@ -55,7 +55,7 @@
           {{paper-button raised=true href=(href-to 'asset' selectedAsset.id) target="_blank" label="View in Admin"}}
           <h2>Asset Metadata (Global)</h2>
           {{paper-input class="editor-dialog__input flex-100" label="Title" value=selectedAsset.title onChange=(action (mut selectedAsset.title))}}
-          {{paper-input class="editor-dialog__input flex-100" label="Credit" value=selectedAsset.credit onChange=(action (mut selectedAsset.credit))}}
+          {{paper-input class="editor-dialog__input flex-100" label="Credit" value=selectedAsset.owner onChange=(action (mut selectedAsset.owner))}}
           {{paper-input 
             class="editor-dialog__input"
             textarea=true 


### PR DESCRIPTION
#### Bug list:
- Cannot update the owner/credit field in either the pop up dialog or asset page
- Cannot update the taken at date field in the asset page

#### Changes presented in this PR
- The owner/credit fields weren't being fed the wrong property, `credit`, instead of `owner`. Changing that for the pop-up editor, and adding a missing `mutate()` function call in the asset page fixed this.
- The previous date picker actually didn't have an onChange listener. I added one and found out that the date picker needs the date format to be in `YYYY-MM-DD` to work, so I had to create a computed property called `takenAtFormatted` that formats the `taken_at` property to `YYYY-MM-DD`. I also found out that the API actually doesn't respond to changes in `taken_at`, but instead for `image_taken`. Given that discovery, I use `taken_at` as a variable to display on the frontend, and `image_taken` as the variable sent to the bankend.

#### Note
I also added a link to the chooser from the index page to make it easy for users to navigate to the chooser screen when logging in from a popup from the CMS. I tried figuring out how to redirect to the chooser immediately after logging into the SSO, but I felt that I wasn't making enough progress. I'll create a new ticket to figure that out.