### PR TITLE
Adjusts features to the Chooser UI, per Melissa's request, and fixes login redirect bug

### DIFF
--- a/frontend/app/components/editor-dialog.js
+++ b/frontend/app/components/editor-dialog.js
@@ -11,22 +11,21 @@ export default Component.extend({
   },
   actions: {
     saveAndClose(){
-      const asset                = this.get('asset'),
-            shouldPersistCaption = asset.get('shouldPersistCaption');
-      if(!shouldPersistCaption) return this.onClose();
+      const asset = this.get('asset');
       this.get('store')
           .findRecord('asset', asset.id)
           .then(record => {
-            if(shouldPersistCaption) record.set('caption', asset.get('caption'));
+            record.setProperties(asset);
             return record.save()
-                         .then(() => {
-                           this.onClose();
-                           if(shouldPersistCaption) this.get('paperToaster').show('Caption successfully saved back to AssetHost.', { toastClass: 'application-toast' });
-                           this.get('paperToaster').show('Asset saved successfully.', { toastClass: 'application-toast' });
-                         });
+              .then(() =>{
+                this.onClose();
+                this.get('paperToaster').show('Asset saved successfully.', { toastClass: 'application-toast' });
+              })
+              .catch(() => {
+                this.get('paperToaster').show('Failed to save asset.', { toastClass: 'application-toast' });
+              });
           })
           .catch(() => {
-            if(shouldPersistCaption) this.get('paperToaster').show('Failed to save caption back to AssetHost.', { toastClass: 'application-toast' });
             this.get('paperToaster').show('Failed to save asset.', { toastClass: 'application-toast' });
           });
     }

--- a/frontend/app/controllers/chooser.js
+++ b/frontend/app/controllers/chooser.js
@@ -36,6 +36,13 @@ export default IndexController.extend({
     closeAssetDialog(){
       this.set('showAssetDialog', false);
     },
+    addAsset(asset){
+      const item = new EmberObject(asset.toJSON());
+      item.id = asset.get('id');
+      const model = this.get('model');
+      model.addObject(item);
+      this.set('showAssetDialog', false);
+    },
     removeAsset(asset){
       const model = this.get('model'),
             index = model.indexOf(asset);

--- a/frontend/app/routes/index.js
+++ b/frontend/app/routes/index.js
@@ -22,6 +22,11 @@ export default Route.extend(AuthenticatedRouteMixin, {
   upload:      alias('assetUpload.upload'),
   search:      service(),
   activate(){
+    // Check if we're in an AssetHost pop-up, and if we are,
+    // automatically transition to the chooser page
+    if (window.opener) {
+      this.transitionTo('chooser');
+    }
     this._super(...arguments);
     this.set('onPaste', bind(this, onPaste));
     if(typeof window === 'object') window.addEventListener('paste', this.get('onPaste'));

--- a/frontend/app/styles/components/asset-bucket.sass
+++ b/frontend/app/styles/components/asset-bucket.sass
@@ -4,6 +4,11 @@
   padding: 0
 
 .asset-bucket__item-thumb
+  animation-name: loading-pulse
+  animation-direction: alternate
+  animation-duration: 0.5s
+  animation-iteration-count: infinite
+  animation-timing-function: ease-in-out
   height: 100%
 
 .asset-bucket__actions
@@ -14,4 +19,10 @@
 
 .asset-bucket__text
   margin-left: 10px
+
+@keyframes loading-pulse
+  from
+    background-color: $color-gray-light
+  to
+    background-color: $color-gray-lightest
 

--- a/frontend/app/templates/chooser.hbs
+++ b/frontend/app/templates/chooser.hbs
@@ -1,3 +1,30 @@
+{{#file-dropzone name="assets" as |dropzone queue|}}
+  <div id="index__drop-zone" class="drop-zone {{if dropzone.active 'drop-zone--active'}}">
+    {{#if dropzone.active}}
+      {{#if dropzone.valid}}
+        Drop to upload
+      {{else}}
+        Invalid
+      {{/if}}
+    {{else if queue.files.length}}
+      Uploading {{queue.files.length}} files. ({{queue.progress}}%)
+    {{else}}
+      <h4 class="drop-zone__heading">Upload Images</h4>
+      <p class="drop-zone__text">
+        {{#if dropzone.supported}}
+          Drag and drop images onto this area to upload them or
+        {{/if}}
+        {{#file-upload name="assets"
+                       accept="image/*"
+                       multiple=true
+                       onfileadd=(action "uploadAsset")}}
+          <a id="upload-image" class="md-default-theme md-button md-raised" tabindex=0>Add an Image.</a>
+        {{/file-upload}}
+      </p>
+    {{/if}}
+  </div>
+{{/file-dropzone}}
+
 <div id="chooser__pane" class="application-pane">
   <div id="chooser__asset-selector" class="chooser__asset-selector">
     <h3>Selected Assets:</h3>
@@ -78,6 +105,7 @@
     {{#paper-dialog-actions class="layout-row"}}
       <span class="flex"></span>
       {{paper-button primary=true href=(href-to 'asset' selectedAsset.id) target="_blank" label="View in Admin"}}
+      {{#paper-button primary=true onClick=(action "addAsset" selectedAsset)}}Select Asset{{/paper-button}}
       {{#paper-button primary=true onClick=(action "closeAssetDialog" "ok" dogName)}}Close{{/paper-button}}
     {{/paper-dialog-actions}}
 

--- a/frontend/app/templates/chooser.hbs
+++ b/frontend/app/templates/chooser.hbs
@@ -49,7 +49,8 @@
             {{/card.actions}}
             {{#card.title as |title|}}
               {{#title.media size="md"}}
-                <div class="asset-bucket__item-thumb card-media" style={{image-background-style asset.urls.lsquare asset.image_gravity}}>
+                <div class="asset-bucket__item-thumb card-media">
+                  <img src={{ asset.urls.lsquare }} />
                 </div>
               {{/title.media}}
               {{#title.text class="asset-bucket__text" as |text|}}

--- a/frontend/app/templates/components/editor-dialog.hbs
+++ b/frontend/app/templates/components/editor-dialog.hbs
@@ -11,7 +11,7 @@
         {{paper-button raised=true href=(href-to 'asset' asset.id) target="_blank" label="View in Admin"}}
         <h2>Asset Metadata (Global)</h2>
         {{paper-input class="editor-dialog__input flex-100" label="Title" value=asset.title onChange=(action (mut asset.title))}}
-        {{paper-input class="editor-dialog__input flex-100" label="Credit" value=asset.credit onChange=(action (mut asset.credit))}}
+        {{paper-input class="editor-dialog__input flex-100" label="Credit" value=asset.owner onChange=(action (mut asset.owner))}}
         {{paper-input 
           class="editor-dialog__input"
           textarea=true 
@@ -40,10 +40,7 @@
     </div>
   {{/paper-dialog-content}}
   {{#paper-dialog-actions class="layout-row"}}
-    {{#paper-button onClick=(action "saveAndClose")}}Save Caption{{/paper-button}}
+    {{#paper-button onClick=(action "saveAndClose")}}Save Metadata{{/paper-button}}
     <span class="flex"></span>
-    {{#paper-checkbox value=asset.shouldPersistCaption onChange=(action (mut asset.shouldPersistCaption))}}
-      Also save caption back to AssetHost for future uses
-    {{/paper-checkbox}}
   {{/paper-dialog-actions}}
 {{/paper-dialog}}


### PR DESCRIPTION
#### Major changes:
- Adds a dropzone component (taken from the `index` page) to the `/chooser` page so that users can upload in the popup, similar to how it works in SCPR's AH
- Can save metadata from the `/chooser` page
- Can add an image to the chooser list by clicking `Select Asset`, similar to how it works in SCPR's AH
- When adding an image to the chooser list immediately after upload, it shows a loading box as it waits for the image to fetch
- (bugfix) Correctly redirects to the `/chooser` page when logging in from a pop-up triggered by LAistMCE
