### PR TITLE
Fix/reorder assethost server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,5 +67,5 @@ USER assethost
 
 EXPOSE 8080
 
-CMD server
+CMD server -e production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,5 +67,5 @@ USER assethost
 
 EXPOSE 8080
 
-CMD server -e production
+CMD rails s -e production -p 8080
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem 'asset_host_kpcc', github: 'scpr/asset_host_kpcc'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 
+# New Relic APM
+gem 'newrelic_rpm', '~> 4.0', '>= 4.0.0.332'
+
 group :development, :test do
   ## These are grouped here because, theoretically,
   ## your assets should already be precompiled when

--- a/bin/server
+++ b/bin/server
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-nginx -g "daemon off;" & rails s $1 $2 $3 $4 $5 $6
+rails s $1 $2 $3 $4 $5 $6 &
+sleep 5
+nginx -g "daemon off;"
 

--- a/bin/server
+++ b/bin/server
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-rails s $1 $2 $3 $4 $5 $6 &
-sleep 5
-nginx -g "daemon off;"
+rails s $1 $2 $3 $4 $5 $6
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   # config.assets.js_compressor = :uglifier

--- a/public/50x.html
+++ b/public/50x.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>We're sorry, but something went wrong</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   body {


### PR DESCRIPTION
# Major changes:
- Runs assethost rails server directly from dockerfile which allows an assethost pod to be able to more quickly serve rails and respond to traffic